### PR TITLE
Improve logging when request is blocked

### DIFF
--- a/lib/wafris/middleware.rb
+++ b/lib/wafris/middleware.rb
@@ -29,7 +29,9 @@ module Wafris
       if Wafris.allow_request?(request)
         @app.call(env)
       else
-        puts 'blocked'
+        LogSuppressor.puts_log(
+          "[Wafris] Blocked: #{request.ip} #{request.request_method} #{request.host} #{request.url}}"
+        )
         [403, {}, ['Blocked']]
       end
     rescue StandardError => e


### PR DESCRIPTION
Currently, wafris prints the literal string "blocked" when a request is blocked. Improve the logging to include basics about the request.

For us, this will allow us to set up alerts/reporting in our logging provider