### PR TITLE
Tweak docs to encourage better initializer config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ Specify your redis with the following initializer. We recommend storing the Redi
 # Create this file and add the following:
 # config/initializers/wafris.rb
 
-Wafris.configure do |c|
+if ENV["WAFRIS_REDIS_URL"]
+  Wafris.configure do |c|
     c.redis = Redis.new(
-      url: ENV['PUT_YOUR_REDIS_URL_HERE']
+      url: ENV["WAFRIS_REDIS_URL"]
     )
+  end
 end
 ```
 


### PR DESCRIPTION
Subjective so it won't hurt my feelings if you reject :)

I made these deviations from the instructions in our app config today.

I think calling out `WAFRIS_REDIS_URL` is a good practice, it encourages people not to reuse `REDIS_URL`.

We also wrapped the initialize to check if the env var was present -- this prevents any unintended things from happening in test/dev environments and allows us to quickly disable Wafris in Heroku (just delete the env var and dynos will reboot). This also allows us to just install the gem in production environments as well.