### PR TITLE
Adding quiet_mode to configuration

### DIFF
--- a/docs/wafris-initalizer.md
+++ b/docs/wafris-initalizer.md
@@ -4,6 +4,7 @@ In your Rails app the Wafris initalizer file:
 
 - Tells Wafris where to find your Redis instance
 - Allows for tuning of the Redis connection pool
+- Allows for enabling quiet mode
 
 ## 1. Create the initializer file
 
@@ -11,9 +12,9 @@ Create a new file in your Rails app at `config/initializers/wafris.rb`
 
 ## 2. Find your Redis Connection URL
 
-Most typically this is exposed as an environment variable in your production environment. 
+Most typically this is exposed as an environment variable in your production environment.
 
-## 3. Copy the base configuration 
+## 3. Copy the base configuration
 
 Copy the following into your `wafris.rb` file:
 
@@ -55,3 +56,15 @@ Wafris.configure do |c|
 end
 ```
 
+## 7. Enable quiet mode
+
+By default Wafris will log status messages when a connection to the application console is opened. If you prefer to silence these messages, you can enable quiet mode:
+
+```ruby
+Wafris.configure do |c|
+    c.redis = Redis.new(
+      url: ENV['PUT_YOUR_REDIS_URL_HERE'],
+    )
+    c.quiet_mode = true
+end
+```

--- a/lib/wafris.rb
+++ b/lib/wafris.rb
@@ -21,7 +21,7 @@ module Wafris
       yield(configuration)
       LogSuppressor.puts_log(
         "[Wafris] attempting firewall connection via Wafris.configure initializer."
-      )
+      ) unless configuration.quiet_mode
       configuration.create_settings
     rescue Redis::CannotConnectError, ArgumentError
       LogSuppressor.puts_log(

--- a/lib/wafris/configuration.rb
+++ b/lib/wafris/configuration.rb
@@ -7,10 +7,12 @@ module Wafris
     attr_accessor :redis
     attr_accessor :redis_pool_size
     attr_accessor :maxmemory
+    attr_accessor :quiet_mode
 
     def initialize
       @redis_pool_size = 20
       @maxmemory = 25
+      @quiet_mode = false
     end
 
     def connection_pool
@@ -25,7 +27,7 @@ module Wafris
                  'maxmemory', @maxmemory)
       LogSuppressor.puts_log(
         "[Wafris] firewall enabled. Connected to Redis on #{redis.connection[:host]}. Ready to process requests. Set rules at: https://wafris.org/hub"
-      )
+      ) unless @quiet_mode
     end
 
     def core_sha

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -12,9 +12,11 @@ module Wafris
       it "allows setting attributes with a block" do
         @config.redis = "some_redis_value"
         @config.redis_pool_size = 30
+        @config.quiet_mode = true
 
         _(@config.redis).must_equal "some_redis_value"
         _(@config.redis_pool_size).must_equal 30
+        _(@config.quiet_mode).must_equal true
       end
     end
 


### PR DESCRIPTION
@rmcastil just playing around with this concept, which would suppress the two non-critical log messages. I've introduced `quiet_mode` as a configuration setting, but perhaps there's a better name?