### PR TITLE
Set `wafris` middleware as the second position for Rails > 6.

### DIFF
--- a/lib/wafris/railtie.rb
+++ b/lib/wafris/railtie.rb
@@ -3,7 +3,11 @@
 module Wafris
   class Railtie < ::Rails::Railtie
     initializer 'wafris.middleware' do |app|
-      app.middleware.use(Wafris::Middleware)
+      if Rails.version > "6" && defined?(ActionDispatch::HostAuthorization)
+        app.middleware.insert_after ActionDispatch::HostAuthorization, Middleware
+      else
+        app.middleware.use(Wafris::Middleware)
+      end
     end
   end
 end

--- a/test/rails_middleware_test.rb
+++ b/test/rails_middleware_test.rb
@@ -14,9 +14,15 @@ if defined?(Rails)
 
     it "is used by default" do
       @app.initialize!
+
       assert @app.middleware.include?(Wafris::Middleware)
     end
 
-    it 'is included at the second position for Rails version greater than 6'
+    it 'is included at the second position for Rails version greater than 6' do
+      @app.initialize!
+
+      assert @app.middleware[0] == ActionDispatch::HostAuthorization
+      assert @app.middleware[0] == Wafris::Middleware
+    end
   end
 end

--- a/test/rails_middleware_test.rb
+++ b/test/rails_middleware_test.rb
@@ -16,5 +16,7 @@ if defined?(Rails)
       @app.initialize!
       assert @app.middleware.include?(Wafris::Middleware)
     end
+
+    it 'is included at the second position for Rails version greater than 6'
   end
 end


### PR DESCRIPTION
The main reason is to load `Wafris::Middleware` after `HostAuthorization`.