### PR TITLE
Do not modify the request body StringIO object

### DIFF
--- a/lib/wafris/wafris_request.rb
+++ b/lib/wafris/wafris_request.rb
@@ -13,7 +13,7 @@ module Wafris
       @host = encode_to_utf8(request.host.to_s)
       @request_method = encode_to_utf8(request.request_method)
       @headers = extract_headers(env)
-      @body = request.body&.read
+      @body = encode_to_utf8(request.body&.string)
       @request_id = env.fetch('action_dispatch.request_id', SecureRandom.uuid.to_s)
       @request_timestamp = Time.now.utc.to_i
     end

--- a/test/wafris_request_test.rb
+++ b/test/wafris_request_test.rb
@@ -8,7 +8,8 @@ class WafrisRequestTest < Minitest::Test
     @mock_request.expect(:params, {'foo' => 'bar'})
     @mock_request.expect(:host, 'example.com')
     @mock_request.expect(:request_method, 'GET')
-    @mock_request.expect(:body, StringIO.new('test body'))
+    @request_body = StringIO.new('test body')
+    @mock_request.expect(:body, @request_body)
     @mock_env = {
       'HTTP_USER_AGENT' => 'MockAgent',
       'HTTP_HOST' => 'example.com',
@@ -35,6 +36,7 @@ class WafrisRequestTest < Minitest::Test
         assert_equal 'GET', wafris_request.request_method
         assert_equal({'HTTP_USER_AGENT' => 'MockAgent', 'HTTP_HOST' => 'example.com'}, wafris_request.headers)
         assert_equal 'test body', wafris_request.body
+        assert_equal 0, @request_body.pos
         assert_equal '123456', wafris_request.request_id
         assert_equal 1234567890, wafris_request.request_timestamp
       end
@@ -45,7 +47,7 @@ class WafrisRequestTest < Minitest::Test
 
   def test_request_id_fallback
     @mock_env.delete('action_dispatch.request_id')
-    
+
     SecureRandom.stub :uuid, '987654321' do
       Wafris::IpResolver.stub(:new, @ip_resolver) do
         wafris_request = Wafris::WafrisRequest.new(@mock_request, @mock_env)


### PR DESCRIPTION
issue: calling `read` moves the offset to the end so the next read is empty
fix: call `string` which does not have side-effects on the StringIO