### PR TITLE
Instrument results with ActiveSupport::Notifications

### DIFF
--- a/lib/wafris/middleware.rb
+++ b/lib/wafris/middleware.rb
@@ -4,6 +4,7 @@ module Wafris
   class Middleware
     def initialize(app)
       @app = app
+      @notifier = ActiveSupport::Notifications if defined?(ActiveSupport::Notifications)
       ProxyFilter.set_filter
     end
 
@@ -23,6 +24,8 @@ module Wafris
         wafris_request.request_id,
         wafris_request.request_timestamp
       )
+
+      @notifier&.instrument("#{treatment}.wafris", request: wafris_request, treatment: treatment)
 
       # These values match what the client tests expect (200, 404, 403, 500)
       if treatment == 'Allowed' || treatment == 'Passed'


### PR DESCRIPTION
This allows users to report results to places like Honeybadger Insights. ;)

```ruby
ActiveSupport::Notifications.subscribe(/wafris/) do |name, start, finish, id, payload|
  Honeybadger.event(name, path: payload[:request].path, treatment: payload[:treatment])
end
```

![Insights - Honeybadger](https://github.com/user-attachments/assets/d7cff9b2-befa-4191-a4f2-4965cb9d4595)

