### PR TITLE
Make http calls concurrent

### DIFF
--- a/lib/wafris.rb
+++ b/lib/wafris.rb
@@ -187,7 +187,7 @@ module Wafris
 
       url_and_api_key = @configuration.upsync_url + "/" + @configuration.api_key
 
-      LogSuppressor.puts_log("[Wafris][Upsync] Beginning request thread...")
+      LogSuppressor.puts_log("[Upsync] Beginning request thread...")
       current_time = Time.now
       response = HTTParty.post(
         url_and_api_key,
@@ -199,13 +199,13 @@ module Wafris
       if response.code == 200
         @configuration.upsync_status = "Complete"
       else
-        LogSuppressor.puts_log("[Wafris][Upsync] Error. HTTP Response: #{response.code}")
+        LogSuppressor.puts_log("[Upsync] Error. HTTP Response: #{response.code}")
       end
     rescue HTTParty::Error => e
-      LogSuppressor.puts_log("[Wafris][Upsync] Thread Error. Failed to send upsync requests: #{e.message}")
+      LogSuppressor.puts_log("[Upsync] Thread Error. Failed to send upsync requests: #{e.message}")
     ensure
       elapsed_time = Time.now - current_time
-      LogSuppressor.puts_log("[Wafris][Upsync] request thread complete in #{elapsed_time.round(2)} seconds.")
+      LogSuppressor.puts_log("[Upsync] request thread complete in #{elapsed_time.round(2)} seconds.")
     end
 
     # This method is used to queue upsync requests. It takes in several parameters including:
@@ -260,10 +260,10 @@ module Wafris
       begin
         lockfile = File.open(lockfile_path, File::RDWR | File::CREAT | File::EXCL)
       rescue Errno::EEXIST
-        LogSuppressor.puts_log("[Wafris][Downsync][downsync_db] Lockfile already exists, skipping downsync.")
+        LogSuppressor.puts_log("[Downsync][downsync_db] Lockfile already exists, skipping downsync.")
         return
       rescue Exception => e
-        LogSuppressor.puts_log("[Wafris][Downsync] Error creating lockfile: #{e.message}")
+        LogSuppressor.puts_log("[Downsync] Error creating lockfile: #{e.message}")
       end
 
       begin
@@ -285,7 +285,7 @@ module Wafris
         # puts "Downloading from #{@configuration.downsync_url}/#{db_rule_category}/#{@configuration.api_key}?current_version=#{current_filename}&process_id=#{Process.pid}"
         uri = "#{@configuration.downsync_url}/#{db_rule_category}/#{@configuration.api_key}?#{data.to_query}"
 
-        LogSuppressor.puts_log("[Wafris][Downsync] Beginning request thread for #{db_rule_category}...")
+        LogSuppressor.puts_log("[Downsync] Beginning request thread for #{db_rule_category}...")
         current_time = Time.now
 
         response = HTTParty.get(
@@ -300,8 +300,8 @@ module Wafris
 
         if response.code == 401
           @configuration.upsync_status = "Disabled"
-          LogSuppressor.puts_log("[Wafris][Downsync] Unauthorized: Bad or missing API key")
-          LogSuppressor.puts_log("[Wafris][Downsync] API Key: #{@configuration.api_key}")
+          LogSuppressor.puts_log("[Downsync] Unauthorized: Bad or missing API key")
+          LogSuppressor.puts_log("[Downsync] API Key: #{@configuration.api_key}")
           filename = current_filename
 
         elsif response.code == 304
@@ -340,12 +340,12 @@ module Wafris
           # DB file is bad or empty so keep using whatever we have now
           else
             filename = old_file_name
-            LogSuppressor.puts_log("[Wafris][Downsync] DB Error - No tables exist in the db file #{@configuration.db_file_path}/#{filename}")
+            LogSuppressor.puts_log("[Downsync] DB Error - No tables exist in the db file #{@configuration.db_file_path}/#{filename}")
           end
 
         end
       rescue => e
-        LogSuppressor.puts_log("[Wafris][Downsync] Error downloading rules: #{e.message}")
+        LogSuppressor.puts_log("[Downsync] Error downloading rules: #{e.message}")
 
       # This gets set even if the API key is bad or other issues
       # to prevent hammering the distribution server on every request
@@ -363,7 +363,7 @@ module Wafris
         File.delete(lockfile_path)
 
         elapsed_time = Time.now - current_time
-        LogSuppressor.puts_log("[Wafris][Downsync] request thread complete in #{elapsed_time.round(2)} seconds for #{db_rule_category}.")
+        LogSuppressor.puts_log("[Downsync] request thread complete in #{elapsed_time.round(2)} seconds for #{db_rule_category}.")
       end
 
       filename
@@ -385,19 +385,19 @@ module Wafris
       # Checks for existing current modfile, which contains the current db filename
       if File.exist?("#{@configuration.db_file_path}/#{db_rule_category}.modfile")
 
-        LogSuppressor.puts_log("[Wafris][Downsync] Modfile exists, skipping downsync")
+        LogSuppressor.puts_log("[Downsync] Modfile exists, skipping downsync")
 
         # Get last Modified Time and current database file name
         last_db_synctime = File.mtime("#{@configuration.db_file_path}/#{db_rule_category}.modfile").to_i
         returned_db = File.read("#{@configuration.db_file_path}/#{db_rule_category}.modfile").strip
 
-        LogSuppressor.puts_log("[Wafris][Downsync] Modfile Last Modified Time: #{last_db_synctime}")
-        LogSuppressor.puts_log("[Wafris][Downsync] DB in Modfile: #{returned_db}")
+        LogSuppressor.puts_log("[Downsync] Modfile Last Modified Time: #{last_db_synctime}")
+        LogSuppressor.puts_log("[Downsync] DB in Modfile: #{returned_db}")
 
         # Check if the db file is older than the interval
         if (Time.now.to_i - last_db_synctime) > sync_interval(db_rule_category)
 
-          LogSuppressor.puts_log("[Wafris][Downsync] DB is older than the interval")
+          LogSuppressor.puts_log("[Downsync] DB is older than the interval")
 
           # Make sure that another process isn't already downloading the rules
           if !File.exist?("#{@configuration.db_file_path}/#{db_rule_category}.lockfile")
@@ -409,7 +409,7 @@ module Wafris
         # Current db is up to date
         else
 
-          LogSuppressor.puts_log("[Wafris][Downsync] DB is up to date")
+          LogSuppressor.puts_log("[Downsync] DB is up to date")
 
           returned_db = File.read("#{@configuration.db_file_path}/#{db_rule_category}.modfile").strip
 
@@ -426,11 +426,11 @@ module Wafris
       # No modfile exists, so download the latest db
       else
 
-        LogSuppressor.puts_log("[Wafris][Downsync] No modfile exists, downloading latest #{db_rule_category} db")
+        LogSuppressor.puts_log("[Downsync] No modfile exists, downloading latest #{db_rule_category} db")
 
         # Make sure that another process isn't already downloading the rules
         if File.exist?("#{@configuration.db_file_path}/#{db_rule_category}.lockfile")
-          LogSuppressor.puts_log("[Wafris][Downsync][current_db] Lockfile exists, skipping downsync")
+          LogSuppressor.puts_log("[Downsync][current_db] Lockfile exists, skipping downsync")
           # Lockfile exists, but no modfile with a db filename
           nil
         else


### PR DESCRIPTION
One of our main rules for the gem is to ensure it has minimal affects on requests. Our upsync and downsync calls need to be removed from the main thread of execution.